### PR TITLE
Add mixed inclusive/exclusive ranges

### DIFF
--- a/lib/lucene-query-parser.js
+++ b/lib/lucene-query-parser.js
@@ -1139,7 +1139,9 @@ module.exports = (function(){
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
-                    'inclusive': true
+                    'inclusive': true,
+                    'inclusive_min': true,
+                    'inclusive_max': true
                 };
             })(pos0, result0[1], result0[5]);
         }
@@ -1235,12 +1237,212 @@ module.exports = (function(){
                   return {
                       'term_min': term_min,
                       'term_max': term_max,
-                      'inclusive': false
+                      'inclusive': false,
+                      'inclusive_min': false,
+                      'inclusive_max': false
                   };
               })(pos0, result0[1], result0[5]);
           }
           if (result0 === null) {
             pos = pos0;
+          }
+          if (result0 === null) {
+            pos0 = pos;
+            pos1 = pos;
+            if (input.charCodeAt(pos) === 123) {
+              result0 = "{";
+              pos++;
+            } else {
+              result0 = null;
+              if (reportFailures === 0) {
+                matchFailed("\"{\"");
+              }
+            }
+            if (result0 !== null) {
+              result1 = parse_unquoted_term();
+              if (result1 !== null) {
+                result2 = [];
+                result3 = parse__();
+                while (result3 !== null) {
+                  result2.push(result3);
+                  result3 = parse__();
+                }
+                if (result2 !== null) {
+                  if (input.substr(pos, 2) === "TO") {
+                    result3 = "TO";
+                    pos += 2;
+                  } else {
+                    result3 = null;
+                    if (reportFailures === 0) {
+                      matchFailed("\"TO\"");
+                    }
+                  }
+                  if (result3 !== null) {
+                    result5 = parse__();
+                    if (result5 !== null) {
+                      result4 = [];
+                      while (result5 !== null) {
+                        result4.push(result5);
+                        result5 = parse__();
+                      }
+                    } else {
+                      result4 = null;
+                    }
+                    if (result4 !== null) {
+                      result5 = parse_unquoted_term();
+                      if (result5 !== null) {
+                        if (input.charCodeAt(pos) === 93) {
+                          result6 = "]";
+                          pos++;
+                        } else {
+                          result6 = null;
+                          if (reportFailures === 0) {
+                            matchFailed("\"]\"");
+                          }
+                        }
+                        if (result6 !== null) {
+                          result0 = [result0, result1, result2, result3, result4, result5, result6];
+                        } else {
+                          result0 = null;
+                          pos = pos1;
+                        }
+                      } else {
+                        result0 = null;
+                        pos = pos1;
+                      }
+                    } else {
+                      result0 = null;
+                      pos = pos1;
+                    }
+                  } else {
+                    result0 = null;
+                    pos = pos1;
+                  }
+                } else {
+                  result0 = null;
+                  pos = pos1;
+                }
+              } else {
+                result0 = null;
+                pos = pos1;
+              }
+            } else {
+              result0 = null;
+              pos = pos1;
+            }
+            if (result0 !== null) {
+              result0 = (function(offset, term_min, term_max) {
+                    return {
+                        'term_min': term_min,
+                        'term_max': term_max,
+                        'inclusive': false,
+                        'inclusive_min': false,
+                        'inclusive_max': true
+                    };
+                })(pos0, result0[1], result0[5]);
+            }
+            if (result0 === null) {
+              pos = pos0;
+            }
+            if (result0 === null) {
+              pos0 = pos;
+              pos1 = pos;
+              if (input.charCodeAt(pos) === 91) {
+                result0 = "[";
+                pos++;
+              } else {
+                result0 = null;
+                if (reportFailures === 0) {
+                  matchFailed("\"[\"");
+                }
+              }
+              if (result0 !== null) {
+                result1 = parse_unquoted_term();
+                if (result1 !== null) {
+                  result2 = [];
+                  result3 = parse__();
+                  while (result3 !== null) {
+                    result2.push(result3);
+                    result3 = parse__();
+                  }
+                  if (result2 !== null) {
+                    if (input.substr(pos, 2) === "TO") {
+                      result3 = "TO";
+                      pos += 2;
+                    } else {
+                      result3 = null;
+                      if (reportFailures === 0) {
+                        matchFailed("\"TO\"");
+                      }
+                    }
+                    if (result3 !== null) {
+                      result5 = parse__();
+                      if (result5 !== null) {
+                        result4 = [];
+                        while (result5 !== null) {
+                          result4.push(result5);
+                          result5 = parse__();
+                        }
+                      } else {
+                        result4 = null;
+                      }
+                      if (result4 !== null) {
+                        result5 = parse_unquoted_term();
+                        if (result5 !== null) {
+                          if (input.charCodeAt(pos) === 125) {
+                            result6 = "}";
+                            pos++;
+                          } else {
+                            result6 = null;
+                            if (reportFailures === 0) {
+                              matchFailed("\"}\"");
+                            }
+                          }
+                          if (result6 !== null) {
+                            result0 = [result0, result1, result2, result3, result4, result5, result6];
+                          } else {
+                            result0 = null;
+                            pos = pos1;
+                          }
+                        } else {
+                          result0 = null;
+                          pos = pos1;
+                        }
+                      } else {
+                        result0 = null;
+                        pos = pos1;
+                      }
+                    } else {
+                      result0 = null;
+                      pos = pos1;
+                    }
+                  } else {
+                    result0 = null;
+                    pos = pos1;
+                  }
+                } else {
+                  result0 = null;
+                  pos = pos1;
+                }
+              } else {
+                result0 = null;
+                pos = pos1;
+              }
+              if (result0 !== null) {
+                result0 = (function(offset, term_min, term_max) {
+                      return {
+                          'term_min': term_min,
+                          'term_max': term_max,
+                          'inclusive': false,
+                          'inclusive_min': true,
+                          'inclusive_max': false
+                      };
+                  })(pos0, result0[1], result0[5]);
+              }
+              if (result0 === null) {
+                pos = pos0;
+              }
+            }
           }
         }
         return result0;

--- a/lib/lucene-query.grammar
+++ b/lib/lucene-query.grammar
@@ -261,7 +261,9 @@ range_operator_exp
         return {
             'term_min': term_min,
             'term_max': term_max,
-            'inclusive': true
+            'inclusive': true,
+            'inclusive_min': true,
+            'inclusive_max': true
         };
     }
   / '{' term_min:unquoted_term _* 'TO' _+ term_max:unquoted_term '}'
@@ -269,7 +271,29 @@ range_operator_exp
         return {
             'term_min': term_min,
             'term_max': term_max,
-            'inclusive': false
+            'inclusive': false,
+            'inclusive_min': false,
+            'inclusive_max': false
+        };
+    }
+  / '{' term_min:unquoted_term _* 'TO' _+ term_max:unquoted_term ']'
+    {
+        return {
+            'term_min': term_min,
+            'term_max': term_max,
+            'inclusive': false,
+            'inclusive_min': false,
+            'inclusive_max': true
+        };
+    }
+  / '[' term_min:unquoted_term _* 'TO' _+ term_max:unquoted_term '}'
+    {
+        return {
+            'term_min': term_min,
+            'term_max': term_max,
+            'inclusive': false,
+            'inclusive_min': true,
+            'inclusive_max': false
         };
     }
 


### PR DESCRIPTION
This change adds support for ranges of the form [10 TO 100} and {10 TO 100]. Mixed ranges are not mentioned in the Lucene spec but work in Kibana/ElasticSearch so it looks like they are valid.
