### PR TITLE
 Handle escaped quotes within quoted terms

### DIFF
--- a/lib/lucene-query-parser.js
+++ b/lib/lucene-query-parser.js
@@ -302,41 +302,43 @@
         peg$c39 = peg$classExpectation(["/"], true, false),
         peg$c40 = "\"",
         peg$c41 = peg$literalExpectation("\"", false),
-        peg$c42 = /^[^"]/,
-        peg$c43 = peg$classExpectation(["\""], true, false),
-        peg$c44 = function(term) {
-                return term.join('');
+        peg$c42 = function(term) {
+                return term.join('').replace(/\\"/g, '"');
             },
-        peg$c45 = "~",
-        peg$c46 = peg$literalExpectation("~", false),
-        peg$c47 = function(proximity) {
+        peg$c43 = "\\\"",
+        peg$c44 = peg$literalExpectation("\\\"", false),
+        peg$c45 = /^[^"]/,
+        peg$c46 = peg$classExpectation(["\""], true, false),
+        peg$c47 = "~",
+        peg$c48 = peg$literalExpectation("~", false),
+        peg$c49 = function(proximity) {
                 return proximity;
             },
-        peg$c48 = "^",
-        peg$c49 = peg$literalExpectation("^", false),
-        peg$c50 = function(boost) {
+        peg$c50 = "^",
+        peg$c51 = peg$literalExpectation("^", false),
+        peg$c52 = function(boost) {
                 return boost;
             },
-        peg$c51 = function(fuzziness) {
+        peg$c53 = function(fuzziness) {
                 return fuzziness == '' || fuzziness == undefined ? 0.5 : fuzziness;
             },
-        peg$c52 = "0.",
-        peg$c53 = peg$literalExpectation("0.", false),
-        peg$c54 = /^[0-9]/,
-        peg$c55 = peg$classExpectation([["0", "9"]], false, false),
-        peg$c56 = function(val) {
+        peg$c54 = "0.",
+        peg$c55 = peg$literalExpectation("0.", false),
+        peg$c56 = /^[0-9]/,
+        peg$c57 = peg$classExpectation([["0", "9"]], false, false),
+        peg$c58 = function(val) {
                 return parseFloat("0." + val.join(''));
             },
-        peg$c57 = function(val) {
+        peg$c59 = function(val) {
                 return parseInt(val.join(''));
             },
-        peg$c58 = "[",
-        peg$c59 = peg$literalExpectation("[", false),
-        peg$c60 = "TO",
-        peg$c61 = peg$literalExpectation("TO", false),
-        peg$c62 = "]",
-        peg$c63 = peg$literalExpectation("]", false),
-        peg$c64 = function(term_min, term_max) {
+        peg$c60 = "[",
+        peg$c61 = peg$literalExpectation("[", false),
+        peg$c62 = "TO",
+        peg$c63 = peg$literalExpectation("TO", false),
+        peg$c64 = "]",
+        peg$c65 = peg$literalExpectation("]", false),
+        peg$c66 = function(term_min, term_max) {
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
@@ -345,11 +347,11 @@
                     'inclusive_max': true
                 };
             },
-        peg$c65 = "{",
-        peg$c66 = peg$literalExpectation("{", false),
-        peg$c67 = "}",
-        peg$c68 = peg$literalExpectation("}", false),
-        peg$c69 = function(term_min, term_max) {
+        peg$c67 = "{",
+        peg$c68 = peg$literalExpectation("{", false),
+        peg$c69 = "}",
+        peg$c70 = peg$literalExpectation("}", false),
+        peg$c71 = function(term_min, term_max) {
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
@@ -358,7 +360,7 @@
                     'inclusive_max': false
                 };
             },
-        peg$c70 = function(term_min, term_max) {
+        peg$c72 = function(term_min, term_max) {
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
@@ -367,7 +369,7 @@
                     'inclusive_max': true
                 };
             },
-        peg$c71 = function(term_min, term_max) {
+        peg$c73 = function(term_min, term_max) {
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
@@ -376,28 +378,28 @@
                     'inclusive_max': false
                 };
             },
-        peg$c72 = function(operator) {
+        peg$c74 = function(operator) {
                 return operator;
             },
-        peg$c73 = "OR",
-        peg$c74 = peg$literalExpectation("OR", false),
-        peg$c75 = "AND",
-        peg$c76 = peg$literalExpectation("AND", false),
-        peg$c77 = "NOT",
-        peg$c78 = peg$literalExpectation("NOT", false),
-        peg$c79 = "||",
-        peg$c80 = peg$literalExpectation("||", false),
-        peg$c81 = function() { return 'OR'; },
-        peg$c82 = "&&",
-        peg$c83 = peg$literalExpectation("&&", false),
-        peg$c84 = function() { return 'AND'; },
-        peg$c85 = "!",
-        peg$c86 = peg$literalExpectation("!", false),
-        peg$c87 = function() { return 'NOT'},
-        peg$c88 = peg$otherExpectation("whitespace"),
-        peg$c89 = /^[ \t\r\n\f]/,
-        peg$c90 = peg$classExpectation([" ", "\t", "\r", "\n", "\f"], false, false),
-        peg$c91 = peg$anyExpectation(),
+        peg$c75 = "OR",
+        peg$c76 = peg$literalExpectation("OR", false),
+        peg$c77 = "AND",
+        peg$c78 = peg$literalExpectation("AND", false),
+        peg$c79 = "NOT",
+        peg$c80 = peg$literalExpectation("NOT", false),
+        peg$c81 = "||",
+        peg$c82 = peg$literalExpectation("||", false),
+        peg$c83 = function() { return 'OR'; },
+        peg$c84 = "&&",
+        peg$c85 = peg$literalExpectation("&&", false),
+        peg$c86 = function() { return 'AND'; },
+        peg$c87 = "!",
+        peg$c88 = peg$literalExpectation("!", false),
+        peg$c89 = function() { return 'NOT'},
+        peg$c90 = peg$otherExpectation("whitespace"),
+        peg$c91 = /^[ \t\r\n\f]/,
+        peg$c92 = peg$classExpectation([" ", "\t", "\r", "\n", "\f"], false, false),
+        peg$c93 = peg$anyExpectation(),
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -1237,23 +1239,11 @@
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c42.test(input.charAt(peg$currPos))) {
-          s3 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c43); }
-        }
+        s3 = peg$parsenon_quote_char();
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c42.test(input.charAt(peg$currPos))) {
-              s3 = input.charAt(peg$currPos);
-              peg$currPos++;
-            } else {
-              s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c43); }
-            }
+            s3 = peg$parsenon_quote_char();
           }
         } else {
           s2 = peg$FAILED;
@@ -1268,7 +1258,7 @@
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c44(s2);
+            s1 = peg$c42(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1286,22 +1276,45 @@
       return s0;
     }
 
+    function peg$parsenon_quote_char() {
+      var s0;
+
+      if (input.substr(peg$currPos, 2) === peg$c43) {
+        s0 = peg$c43;
+        peg$currPos += 2;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c44); }
+      }
+      if (s0 === peg$FAILED) {
+        if (peg$c45.test(input.charAt(peg$currPos))) {
+          s0 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c46); }
+        }
+      }
+
+      return s0;
+    }
+
     function peg$parseproximity_modifier() {
       var s0, s1, s2;
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 126) {
-        s1 = peg$c45;
+        s1 = peg$c47;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c46); }
+        if (peg$silentFails === 0) { peg$fail(peg$c48); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseint_exp();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c47(s2);
+          s1 = peg$c49(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1320,17 +1333,17 @@
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 94) {
-        s1 = peg$c48;
+        s1 = peg$c50;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsedecimal_or_int_exp();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c50(s2);
+          s1 = peg$c52(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1349,11 +1362,11 @@
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 126) {
-        s1 = peg$c45;
+        s1 = peg$c47;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c46); }
+        if (peg$silentFails === 0) { peg$fail(peg$c48); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsedecimal_exp();
@@ -1362,7 +1375,7 @@
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c51(s2);
+          s1 = peg$c53(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1391,31 +1404,31 @@
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c52) {
-        s1 = peg$c52;
+      if (input.substr(peg$currPos, 2) === peg$c54) {
+        s1 = peg$c54;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c54.test(input.charAt(peg$currPos))) {
+        if (peg$c56.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c54.test(input.charAt(peg$currPos))) {
+            if (peg$c56.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c55); }
+              if (peg$silentFails === 0) { peg$fail(peg$c57); }
             }
           }
         } else {
@@ -1423,7 +1436,7 @@
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c56(s2);
+          s1 = peg$c58(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1442,22 +1455,22 @@
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c54.test(input.charAt(peg$currPos))) {
+      if (peg$c56.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+        if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c54.test(input.charAt(peg$currPos))) {
+          if (peg$c56.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c57); }
           }
         }
       } else {
@@ -1465,7 +1478,7 @@
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c57(s1);
+        s1 = peg$c59(s1);
       }
       s0 = s1;
 
@@ -1477,11 +1490,11 @@
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c58;
+        s1 = peg$c60;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseunquoted_term();
@@ -1493,12 +1506,12 @@
             s4 = peg$parse_();
           }
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c60) {
-              s4 = peg$c60;
+            if (input.substr(peg$currPos, 2) === peg$c62) {
+              s4 = peg$c62;
               peg$currPos += 2;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c61); }
+              if (peg$silentFails === 0) { peg$fail(peg$c63); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -1515,15 +1528,15 @@
                 s6 = peg$parseunquoted_term();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s7 = peg$c62;
+                    s7 = peg$c64;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c63); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c65); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c64(s2, s6);
+                    s1 = peg$c66(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1556,11 +1569,11 @@
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 123) {
-          s1 = peg$c65;
+          s1 = peg$c67;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          if (peg$silentFails === 0) { peg$fail(peg$c68); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseunquoted_term();
@@ -1572,12 +1585,12 @@
               s4 = peg$parse_();
             }
             if (s3 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c60) {
-                s4 = peg$c60;
+              if (input.substr(peg$currPos, 2) === peg$c62) {
+                s4 = peg$c62;
                 peg$currPos += 2;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c61); }
+                if (peg$silentFails === 0) { peg$fail(peg$c63); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = [];
@@ -1594,15 +1607,15 @@
                   s6 = peg$parseunquoted_term();
                   if (s6 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s7 = peg$c67;
+                      s7 = peg$c69;
                       peg$currPos++;
                     } else {
                       s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c68); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c70); }
                     }
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c69(s2, s6);
+                      s1 = peg$c71(s2, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1635,11 +1648,11 @@
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 123) {
-            s1 = peg$c65;
+            s1 = peg$c67;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c66); }
+            if (peg$silentFails === 0) { peg$fail(peg$c68); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseunquoted_term();
@@ -1651,12 +1664,12 @@
                 s4 = peg$parse_();
               }
               if (s3 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c60) {
-                  s4 = peg$c60;
+                if (input.substr(peg$currPos, 2) === peg$c62) {
+                  s4 = peg$c62;
                   peg$currPos += 2;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c61); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c63); }
                 }
                 if (s4 !== peg$FAILED) {
                   s5 = [];
@@ -1673,15 +1686,15 @@
                     s6 = peg$parseunquoted_term();
                     if (s6 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 93) {
-                        s7 = peg$c62;
+                        s7 = peg$c64;
                         peg$currPos++;
                       } else {
                         s7 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c63); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c65); }
                       }
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c70(s2, s6);
+                        s1 = peg$c72(s2, s6);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1714,11 +1727,11 @@
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 91) {
-              s1 = peg$c58;
+              s1 = peg$c60;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c59); }
+              if (peg$silentFails === 0) { peg$fail(peg$c61); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$parseunquoted_term();
@@ -1730,12 +1743,12 @@
                   s4 = peg$parse_();
                 }
                 if (s3 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c60) {
-                    s4 = peg$c60;
+                  if (input.substr(peg$currPos, 2) === peg$c62) {
+                    s4 = peg$c62;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c61); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c63); }
                   }
                   if (s4 !== peg$FAILED) {
                     s5 = [];
@@ -1752,15 +1765,15 @@
                       s6 = peg$parseunquoted_term();
                       if (s6 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 125) {
-                          s7 = peg$c67;
+                          s7 = peg$c69;
                           peg$currPos++;
                         } else {
                           s7 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c68); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c70); }
                         }
                         if (s7 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c71(s2, s6);
+                          s1 = peg$c73(s2, s6);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -1822,7 +1835,7 @@
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c72(s2);
+            s1 = peg$c74(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1850,7 +1863,7 @@
             s3 = peg$parseEOF();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c72(s2);
+              s1 = peg$c74(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1872,69 +1885,69 @@
     function peg$parseoperator() {
       var s0, s1;
 
-      if (input.substr(peg$currPos, 2) === peg$c73) {
-        s0 = peg$c73;
+      if (input.substr(peg$currPos, 2) === peg$c75) {
+        s0 = peg$c75;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        if (peg$silentFails === 0) { peg$fail(peg$c76); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c75) {
-          s0 = peg$c75;
+        if (input.substr(peg$currPos, 3) === peg$c77) {
+          s0 = peg$c77;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c77) {
-            s0 = peg$c77;
+          if (input.substr(peg$currPos, 3) === peg$c79) {
+            s0 = peg$c79;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c78); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c79) {
-              s1 = peg$c79;
+            if (input.substr(peg$currPos, 2) === peg$c81) {
+              s1 = peg$c81;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c80); }
+              if (peg$silentFails === 0) { peg$fail(peg$c82); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c81();
+              s1 = peg$c83();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 2) === peg$c82) {
-                s1 = peg$c82;
+              if (input.substr(peg$currPos, 2) === peg$c84) {
+                s1 = peg$c84;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                if (peg$silentFails === 0) { peg$fail(peg$c85); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c84();
+                s1 = peg$c86();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 33) {
-                  s1 = peg$c85;
+                  s1 = peg$c87;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c86); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c88); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c87();
+                  s1 = peg$c89();
                 }
                 s0 = s1;
               }
@@ -1960,7 +1973,7 @@
         s2 = peg$parseprefix_operator();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c72(s2);
+          s1 = peg$c74(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2002,22 +2015,22 @@
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c89.test(input.charAt(peg$currPos))) {
+      if (peg$c91.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c90); }
+        if (peg$silentFails === 0) { peg$fail(peg$c92); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c89.test(input.charAt(peg$currPos))) {
+          if (peg$c91.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c90); }
+            if (peg$silentFails === 0) { peg$fail(peg$c92); }
           }
         }
       } else {
@@ -2026,7 +2039,7 @@
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c88); }
+        if (peg$silentFails === 0) { peg$fail(peg$c90); }
       }
 
       return s0;
@@ -2042,7 +2055,7 @@
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c91); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       peg$silentFails--;
       if (s1 === peg$FAILED) {

--- a/lib/lucene-query.grammar
+++ b/lib/lucene-query.grammar
@@ -254,12 +254,14 @@ regexpr_term
 regexpr_char
   = '.' / '\\/' / [^/]
 
-
 quoted_term
-  = '"' term:[^"]+ '"'
+  = '"' term:non_quote_char+ '"'
     {
-        return term.join('');
+        return term.join('').replace(/\\"/g, '"');
     }
+
+non_quote_char
+  = '\\"' / [^"]
 
 proximity_modifier
   = '~' proximity:int_exp

--- a/spec/lucene-query-parser.spec.js
+++ b/spec/lucene-query-parser.spec.js
@@ -72,6 +72,13 @@ describe("lucenequeryparser: term parsing", function() {
       expect(results['left']['term']).toBe('GALAXY\\ S8\\+');
     });
 
+    it("handles escaped quotes within quoted terms", function() {
+        var results = lucenequeryparser.parse('foo:"bar \\"baz\\""');
+
+        expect(results['left']['field']).toBe('foo');
+        expect(results['left']['term']).toBe('bar "baz"');
+    });
+
     it("handles empty term with operator", function() {
       expect(function () {
         lucenequeryparser.parse('device_model: AND x:y');
@@ -618,12 +625,5 @@ describe("lucenequeryparser: Lucene Query syntax documentation examples", functi
   });
 
   xdescribe("lucenequeryparser: pending tests", function() {
-    // see issue: https://github.com/thoward/lucene-query-parser.js/issues/1
-    it("handles escaped quotes", function() {
-      var results = lucenequeryparser.parse('foo:"bar \"baz\""');
-
-      expect(results['left']['field']).toBe('foo');
-      expect(results['left']['term']).toBe('bar \"baz\"');
-    });
   });
 });


### PR DESCRIPTION
Fixes issue #1 

Escaped quotes within a quoted term no longer cause a parse error. The resulting term's value contains the inner quotes unescaped. Promoted the preexisting pending unit test, with some tweaks.